### PR TITLE
Copy source files to files named with the digest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ version := "1.0.0-SNAPSHOT"
 
 resolvers += Classpaths.sbtPluginSnapshots
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.0-M2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.0.0-SNAPSHOT")
 
 // FIXME: Working around https://github.com/sbt/sbt/issues/1156#issuecomment-39317363
 isSnapshot := true

--- a/src/sbt-test/digest/defaults/build.sbt
+++ b/src/sbt-test/digest/defaults/build.sbt
@@ -2,7 +2,10 @@ lazy val root = (project in file(".")).addPlugins(SbtWeb)
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "css/a.css.md5", "js", "js/a.js", "js/a.js.md5")
+val expected = Set(
+  "css", "css/a.css", "css/a.css.md5", "css/d41d8cd98f00b204e9800998ecf8427e-a.css",
+  "js", "js/a.js", "js/a.js.md5", "js/d41d8cd98f00b204e9800998ecf8427e-a.js"
+)
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 

--- a/src/sbt-test/digest/exclude/build.sbt
+++ b/src/sbt-test/digest/exclude/build.sbt
@@ -6,7 +6,7 @@ excludeFilter in DigestKeys.addChecksums := "*.css"
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.md5")
+val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.md5", "js/d41d8cd98f00b204e9800998ecf8427e-a.js")
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 

--- a/src/sbt-test/digest/include/build.sbt
+++ b/src/sbt-test/digest/include/build.sbt
@@ -6,7 +6,7 @@ includeFilter in DigestKeys.addChecksums := "*.js"
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.md5")
+val expected = Set("css", "css/a.css", "js", "js/a.js", "js/a.js.md5", "js/d41d8cd98f00b204e9800998ecf8427e-a.js")
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 

--- a/src/sbt-test/digest/sha1/build.sbt
+++ b/src/sbt-test/digest/sha1/build.sbt
@@ -6,7 +6,10 @@ DigestKeys.algorithms += "sha1"
 
 // for checking that the produced pipeline mappings are correct
 
-val expected = Set("css", "css/a.css", "css/a.css.md5", "css/a.css.sha1", "js", "js/a.js", "js/a.js.md5", "js/a.js.sha1")
+val expected = Set(
+  "css", "css/a.css", "css/a.css.md5", "css/a.css.sha1", "css/d41d8cd98f00b204e9800998ecf8427e-a.css", "css/da39a3ee5e6b4b0d3255bfef95601890afd80709-a.css",
+  "js", "js/a.js", "js/a.js.md5", "js/a.js.sha1", "js/d41d8cd98f00b204e9800998ecf8427e-a.js", "js/da39a3ee5e6b4b0d3255bfef95601890afd80709-a.js"
+)
 
 val checkMappings = taskKey[Unit]("check the pipeline mappings")
 


### PR DESCRIPTION
Now supports the copying of each source file to a file with the digest in its name in support of serving up fingerprinted files.
