### PR TITLE
Fix empty root directory being generated on Windows

### DIFF
--- a/src/main/scala/com/typesafe/sbt/digest/SbtDigest.scala
+++ b/src/main/scala/com/typesafe/sbt/digest/SbtDigest.scala
@@ -271,7 +271,7 @@ object SbtDigest extends AutoPlugin {
      */
     def buildPath(base: String, name: String, ext: String): String = {
       val suffix = if (ext.isEmpty) "" else ("." + ext)
-      (file(base) / (name + suffix)).getPath
+      (file(base) / (name + suffix)).getPath.stripPrefix("\\")
     }
 
     /**


### PR DESCRIPTION
When I run `stage` on Windows, the root assets are put into a directory whose name is an empty string.

The expected directory structure:
```
<root>/web.min.js
<root>/web.min.js.md5
<root>/da824655d610243d19259834ee63c94f-web.min.js
```

The actual directory structure:
```
<root>/web.min.js
<root>/<empty>/web.min.js.md5
<root>/<empty>/da824655d610243d19259834ee63c94f-web.min.js
```

Consequently the digested assets don't get picked up by Play. Assets in subdirectories work fine.

The PathMapping gets generated like this:
```
VersionedMapping(web.min.js,md5,da824655d610243d19259834ee63c94f,(Z:\express\webview\target\web\digest\da824655d610243d19259834ee63c94f-web.min.js,\da824655d610243d19259834ee63c94f-web.min.js))
```
This PR strips the extra leading backslash from `\da824655d610243d19259834ee63c94f-web.min.js`