### PR TITLE
Bug where if base = "" it would incorrectly create a leading / #21

### DIFF
--- a/src/main/scala/com/typesafe/sbt/digest/SbtDigest.scala
+++ b/src/main/scala/com/typesafe/sbt/digest/SbtDigest.scala
@@ -269,7 +269,10 @@ object SbtDigest extends AutoPlugin {
      */
     def buildPath(base: String, name: String, ext: String): String = {
       val suffix = if (ext.isEmpty) "" else ("." + ext)
-      (file(base) / (name + suffix)).getPath.stripPrefix("\\")
+      if (base == "") // Corner case, if base is "" we dont create a leading /
+        (name + suffix).stripPrefix("\\")
+      else
+        (file(base) / (name + suffix)).getPath.stripPrefix("\\")
     }
 
     /**


### PR DESCRIPTION
This fixes #21 

Basically what happened is that if the base path was `""` (which meant it was in the root of the folder), sbt-digest would create a path with a leading `/`. This means that physically on the file system the digest'ed file would be placed in the exact same location however the `META-INF` generated in the jar would have an incorrect entry with a double `/`, i.e. `//` which would affect resource lookups.

This means if you physically unzipped the jar the paths would line up fine however looking up resources (using `getClass.getResourceAsStream` or other variants) would fail unless you put a double `//`,

i.e. assuming you have `WebKeys.packagePrefix in Assets := "public/"`

```scala
printResourceAsStream("/public/8582ad69409ecf661cc901a281d8a30c-client-fastopt.js")
```

Would fail however

```scala
printResourceAsStream("/public//8582ad69409ecf661cc901a281d8a30c-client-fastopt.js")
```

Would succeed (notice the extra `/` after `public`)

This bug most likely was never noticed in Play because Play happens to place its assets in folders and doesn't put any assets in the root folder to get digested, however if you used sbt-digest manually and you digested assets in the root folder then you would get the error (as evidenced in https://github.com/mdedetrich/akka-http-with-scalajs-digest-issue)

@jroper Can you let me know when you merge + release this?